### PR TITLE
Enemyクラスの修正とGameシーンでの変数改善

### DIFF
--- a/Minge2022Summer/empty.xcodeproj/project.pbxproj
+++ b/Minge2022Summer/empty.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		2C5C470F26B4F08A005E8C85 /* libopus.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C5C470D26B4F08A005E8C85 /* libopus.a */; };
 		2C5C471126B4F08E005E8C85 /* libzlib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C5C471026B4F08E005E8C85 /* libzlib.a */; };
 		2C6906D82298140F00A427D0 /* engine in Resources */ = {isa = PBXBuildFile; fileRef = 2C6906D72298140F00A427D0 /* engine */; };
+		2CCB96B428F29E3800BEB395 /* LoadCSV.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2CCB96B328F29E3800BEB395 /* LoadCSV.cpp */; };
 		2CD8412C283263B2005013A6 /* libboost_filesystem.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CD8412B283263B2005013A6 /* libboost_filesystem.a */; };
 		2CDF46D028D7184800D71A73 /* SwordZombie.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2CDF46CE28D7184800D71A73 /* SwordZombie.cpp */; };
 		398F50AC28CDD4F8006D7A50 /* GameClear.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 398F50AB28CDD4F7006D7A50 /* GameClear.cpp */; };
@@ -86,6 +87,7 @@
 		2C6906D72298140F00A427D0 /* engine */ = {isa = PBXFileReference; lastKnownFileType = folder; name = engine; path = App/engine; sourceTree = "<group>"; };
 		2C7AE38928E02D2600306D27 /* Stair.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Stair.hpp; sourceTree = "<group>"; };
 		2C7AE38A28E02D2600306D27 /* Object.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Object.hpp; sourceTree = "<group>"; };
+		2CCB96B328F29E3800BEB395 /* LoadCSV.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LoadCSV.cpp; sourceTree = "<group>"; };
 		2CD8412B283263B2005013A6 /* libboost_filesystem.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libboost_filesystem.a; path = ../../lib/macOS/boost/libboost_filesystem.a; sourceTree = "<group>"; };
 		2CDF46CE28D7184800D71A73 /* SwordZombie.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SwordZombie.cpp; sourceTree = "<group>"; };
 		2CDF46CF28D7184800D71A73 /* SwordZombie.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = SwordZombie.hpp; sourceTree = "<group>"; };
@@ -96,7 +98,6 @@
 		F2FCF15E28CD388A00E40211 /* Game.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Game.cpp; sourceTree = "<group>"; };
 		F2FCF15F28CD388A00E40211 /* Title.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Title.cpp; sourceTree = "<group>"; };
 		F2FCF16028CD388A00E40211 /* MapChip.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = MapChip.hpp; sourceTree = "<group>"; };
-		F2FCF16128CD388A00E40211 /* LoadCSV.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = LoadCSV.hpp; sourceTree = "<group>"; };
 		F2FCF16228CD388A00E40211 /* common.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = common.hpp; sourceTree = "<group>"; };
 		F2FCF16328CD388A00E40211 /* Main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Main.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -222,7 +223,7 @@
 				2C2137F728D6F1DD00298E62 /* Character.cpp */,
 				2C2137F628D6F1DD00298E62 /* Character.hpp */,
 				F2FCF16028CD388A00E40211 /* MapChip.hpp */,
-				F2FCF16128CD388A00E40211 /* LoadCSV.hpp */,
+				2CCB96B328F29E3800BEB395 /* LoadCSV.cpp */,
 				F2FCF16228CD388A00E40211 /* common.hpp */,
 				F2FCF16328CD388A00E40211 /* Main.cpp */,
 			);
@@ -316,6 +317,7 @@
 				2C33F94828E4065200079803 /* Enemy.cpp in Sources */,
 				2CDF46D028D7184800D71A73 /* SwordZombie.cpp in Sources */,
 				F2FCF16628CD388A00E40211 /* Main.cpp in Sources */,
+				2CCB96B428F29E3800BEB395 /* LoadCSV.cpp in Sources */,
 				F2FCF16528CD388A00E40211 /* Title.cpp in Sources */,
 				2C2137FD28D6F58E00298E62 /* Player.cpp in Sources */,
 				F2FCF16428CD388A00E40211 /* Game.cpp in Sources */,

--- a/Minge2022Summer/src/Character.hpp
+++ b/Minge2022Summer/src/Character.hpp
@@ -56,13 +56,13 @@ public:
 
 	Character();
 
-	void update();
+	virtual void update();
 	//void decideDirection();			//プレイヤーの方向を決める
 	void moveRestriction(Grid<int>);		//移動制限
 	void groundMapChipCollision(Grid<int>);        //マップチップとの当たり判定処理
 	void moveNextPosition();		//プレイヤーの移動
 
-	void draw() const;
+	virtual void draw() const;
 
 };
 

--- a/Minge2022Summer/src/Player.cpp
+++ b/Minge2022Summer/src/Player.cpp
@@ -1,4 +1,5 @@
 ﻿# include "Player.hpp"
+
 Player::Player(){
     hp=1;
     for(int32 i=0;i<MAXENEMIESNUM;i++){
@@ -21,11 +22,12 @@ void Player::update(){
 	moveNextPosition();
 }
 
-void Player::getenemiespos(Vec2 pos[MAXENEMIESNUM]){
-    for(int32 i=0;i<MAXENEMIESNUM;i++){
-        enemiespos[i]=pos[i];
-    }
+void Player::detectEnemyCollision(Enemy * enemy) {
+	if (enemy->pos.distanceFrom(pos) < 16) {
+		hp--;
+	}
 }
+
 void Player::draw() const {
 	// 歩行のアニメーションのインデックス(x, y)
 	Vec2 animationIndex{ 0, 0 };

--- a/Minge2022Summer/src/Player.cpp
+++ b/Minge2022Summer/src/Player.cpp
@@ -46,6 +46,7 @@ void Player::draw() const {
 					pos.y - textureCenter.y
 		);
 }
+
 bool Player::died(){
     if(hp<=0){
         return true;

--- a/Minge2022Summer/src/Player.hpp
+++ b/Minge2022Summer/src/Player.hpp
@@ -1,5 +1,6 @@
 ﻿#pragma once
 # include "Character.hpp"
+# include "Scenes/Enemies/Enemy.hpp"
 #define MAXENEMIESNUM 100
 
 class Player : public Character{
@@ -12,9 +13,9 @@ private:
 public:
     Player();
     void update();
-    void getenemiespos(Vec2[]);
 	void draw() const;		//プレイヤーの歩行の描画
     bool died();
 	void decideDirection();
+	void detectEnemyCollision(Enemy*);
 
 };

--- a/Minge2022Summer/src/Scenes/Enemies/Enemy.cpp
+++ b/Minge2022Summer/src/Scenes/Enemies/Enemy.cpp
@@ -1,1 +1,6 @@
 ﻿#include"Enemy.hpp"
+
+
+void Enemy::getPlayerPos(Vec2 _playerPos) {
+	playerPos = _playerPos;
+}

--- a/Minge2022Summer/src/Scenes/Enemies/Enemy.hpp
+++ b/Minge2022Summer/src/Scenes/Enemies/Enemy.hpp
@@ -2,4 +2,6 @@
 class Enemy : public Character{
 private:
 public:
+	Vec2 playerPos;
+	void getPlayerPos(Vec2);
 };

--- a/Minge2022Summer/src/Scenes/Enemies/Enemy.hpp
+++ b/Minge2022Summer/src/Scenes/Enemies/Enemy.hpp
@@ -1,4 +1,6 @@
-﻿#include"../../Character.hpp"
+﻿# pragma once
+
+#include"../../Character.hpp"
 class Enemy : public Character{
 private:
 public:

--- a/Minge2022Summer/src/Scenes/Enemies/SwordZombie.cpp
+++ b/Minge2022Summer/src/Scenes/Enemies/SwordZombie.cpp
@@ -1,29 +1,27 @@
 ﻿#include"SwordZombie.hpp"
-SwordZombie::SwordZombie(){
-    playerpos={1000,1000};
+
+SwordZombie::SwordZombie(Point mapPos){
     speed=0.25;
     velocity={0,0};
+	pos = { mapPos.x + collisionSize.x / 2, mapPos.y + collisionSize.y / 2 };
 }
-void SwordZombie::update(Vec2 playerpos){
-    if(pos.x<playerpos.x){
+void SwordZombie::update(){
+    if(pos.x<playerPos.x){
         velocity.x=speed;
     }
-    if(pos.x>playerpos.x){
+    if(pos.x>playerPos.x){
         velocity.x=-speed;
     }
-    if(pos.y<playerpos.y){
+    if(pos.y<playerPos.y){
         velocity.y=speed;
     }
-    if(pos.y>playerpos.y){
+    if(pos.y>playerPos.y){
         velocity.y=-speed;
     }
+
+	moveRestriction(mapLayer1);
+	moveNextPosition();
 }
-void SwordZombie::draw()const{
+void SwordZombie::draw() const {
     mapchip.get(5).draw(pos.x-collisionSize.x/2,pos.y-collisionSize.y/2);
-}
-void SwordZombie::getmypos(Point mypos){
-    pos={mypos.x+collisionSize.x/2,mypos.y+collisionSize.y/2};
-}
-Vec2 SwordZombie::sendmypos(){
-    return pos;
 }

--- a/Minge2022Summer/src/Scenes/Enemies/SwordZombie.hpp
+++ b/Minge2022Summer/src/Scenes/Enemies/SwordZombie.hpp
@@ -1,13 +1,10 @@
 ﻿#include"Enemy.hpp"
 class SwordZombie : public Enemy{
 private:
-    Vec2 playerpos;
     MapChip mapchip;
     double speed;
 public:
-    SwordZombie();
-    void update(Vec2);
-    void draw()const;
-    void getmypos(Point);
-    Vec2 sendmypos();
+    SwordZombie(Point);
+    void update() override;
+    void draw()const override;
 };

--- a/Minge2022Summer/src/Scenes/Enemies/SwordZombie.hpp
+++ b/Minge2022Summer/src/Scenes/Enemies/SwordZombie.hpp
@@ -1,4 +1,5 @@
-﻿#include"Enemy.hpp"
+﻿# pragma once
+#include"Enemy.hpp"
 class SwordZombie : public Enemy{
 private:
     MapChip mapchip;

--- a/Minge2022Summer/src/Scenes/Game.cpp
+++ b/Minge2022Summer/src/Scenes/Game.cpp
@@ -67,7 +67,6 @@ void Game::update()
 	camera.update();
 
 	// プレイヤーの状態更新
-	player.getenemiespos(enemiespos);
 	player.update();
 
 
@@ -78,6 +77,7 @@ void Game::update()
 	for (auto& enemy : enemies) {
 		enemy->getPlayerPos(player.pos);
 		enemy->update();
+		player.detectEnemyCollision(enemy);
 	}
 
 	// ゲームクリア領域の当たり判定

--- a/Minge2022Summer/src/Scenes/Game.cpp
+++ b/Minge2022Summer/src/Scenes/Game.cpp
@@ -2,34 +2,37 @@
 //# include "../LoadCSV.hpp"
 
 Game::Game(const InitData& init)
-: IScene{ init }
+	: IScene{ init }
 {
-    for(int32 i=0;i<MAXENEMIESNUM;i++){
-        enemiespos[i]={1000,1000};
-    }
-    stairs << new Stair(Vec2{ 150, 150 }, Vec2{ 250, 600 }, true);
-    countswordzombies=0;
-    mapLayer0 = LoadCSV(U"layer0.csv");
-    mapLayer1 = LoadCSV(U"layer1.csv");
-    for (int32 y = 0; y < MapSize.y; ++y)
-    {
-        for (int32 x = 0; x < MapSize.x; ++x)
-        {
-            const Point pos{ (x * MapChip::MapChipSize), (y * MapChip::MapChipSize) };
-            if (mapLayer1[y][x] == 5)
-            {
-                swordzombie[countswordzombies].getmypos(pos);
-                countswordzombies++;
-            }
-        }
-    }
+	for (int32 i = 0; i < MAXENEMIESNUM; i++) {
+		enemiespos[i] = { 1000,1000 };
+	}
+	stairs << new Stair(Vec2{ 150, 150 }, Vec2{ 250, 600 }, true);
+	countswordzombies = 0;
+	mapLayer0 = LoadCSV(U"layer0.csv");
+	mapLayer1 = LoadCSV(U"layer1.csv");
 
-    if ((mapLayer0.size() != MapSize) || (mapLayer1.size() != MapSize)) {
-        // MapSize と、ロードしたデータのサイズが一致しない場合のエラー
-        throw Error{ U"mapLayer0: {}, mapLayer1: {}"_fmt(mapLayer0.size(), mapLayer1.size()) };
-    }
-    // マップを 320x240 のレンダーテクスチャに描画し、それを最終的に 2 倍サイズで描画する
-    renderTexture = RenderTexture{ 320, 240 };
+	// layer1上の敵を読み込む
+	for (int32 y = 0; y < MapSize.y; ++y)
+	{
+		for (int32 x = 0; x < MapSize.x; ++x)
+		{
+			const Point pos{ (x * MapChip::MapChipSize), (y * MapChip::MapChipSize) };
+			switch(mapLayer1[y][x])
+			{
+			case 5:
+				enemies << new SwordZombie(pos);
+				break;
+			}
+		}
+	}
+
+	if ((mapLayer0.size() != MapSize) || (mapLayer1.size() != MapSize)) {
+		// MapSize と、ロードしたデータのサイズが一致しない場合のエラー
+		throw Error{ U"mapLayer0: {}, mapLayer1: {}"_fmt(mapLayer0.size(), mapLayer1.size()) };
+	}
+	// マップを 320x240 のレンダーテクスチャに描画し、それを最終的に 2 倍サイズで描画する
+	renderTexture = RenderTexture{ 320, 240 };
 
 	// カメラの位置と大きさを初期化
 	camera.setScreen(Rect(Scene::Size()));
@@ -63,33 +66,19 @@ void Game::update()
 
 	camera.update();
 
-    //camera.update();
-    //const auto t = camera.createTransformer();
-    for(int32 i=0;i<countswordzombies;i++){
-        enemiespos[i]=swordzombie[i].sendmypos();
-    }
-    player.getenemiespos(enemiespos);
-    player.update();
- //   //////////////////////
- //   // プレイヤーの移動
- //   //////////////////////
-
-	////プレイヤーの方向の変更
-	//player.decideDirection();
- //   
+	// プレイヤーの状態更新
+	player.getenemiespos(enemiespos);
+	player.update();
 
 
-	////移動制限処理
- //   player.moveRestriction(mapLayer1);
- //   player.groundMapChipCollision(mapLayer0);
-	////プレイヤーの移動
- //   player.moveNextPosition();
+	//for (int32 i = 0; i < countswordzombies; i++) {
+	//	enemiespos[i] = swordzombie[i].sendmypos();
+	//}
 
-    for(int32 i=0;i<countswordzombies;i++){
-        swordzombie[i].moveRestriction(mapLayer1);
-        swordzombie[i].moveNextPosition();
-        swordzombie[i].update(player.pos);
-    }
+	for (auto& enemy : enemies) {
+		enemy->getPlayerPos(player.pos);
+		enemy->update();
+	}
 
 	// ゲームクリア領域の当たり判定
 	if (gameClearBody.intersects(Rect{
@@ -101,58 +90,58 @@ void Game::update()
 	{
 		changeScene(U"GameClear");
 	}
-    if(player.died()){
-        changeScene(U"GameClear");
-    }
+	if (player.died()) {
+		changeScene(U"GameClear");
+	}
 }
 
 void Game::draw() const
 {
-    {
+	{
 		auto t = camera.createTransformer();
 		//auto sv = camera.createScopedViewport();
 
-        // renderTexture を描画先として設定
-        // const ScopedRenderTarget2D rt{ renderTexture };
-        
-        // マップ
-        for (int32 y = 0; y < MapSize.y; ++y)
-        {
-            for (int32 x = 0; x < MapSize.x; ++x)
-            {
-                // マップチップの描画座標
-                const Point pos{ (x * MapChip::MapChipSize), (y * MapChip::MapChipSize) };
-                
-                // 地面のマップチップ
-                if (const int32 chipIndex = mapLayer0[y][x];
-                    chipIndex != 0) // 0 の場合は描画しない
-                {
-                    mapchip.get(chipIndex).draw(pos);
-                }
-                
-                // 障害物のマップチップ
-                if (const int32 chipIndex = mapLayer1[y][x];
-                    chipIndex == 2) // 0 の場合は描画しない
-                {
-                    mapchip.get(chipIndex).draw(pos);
-                }
-            }
-        }
-        for(int32 i=0;i<countswordzombies;i++){
-            swordzombie[i].draw();
-        }
+		// renderTexture を描画先として設定
+		// const ScopedRenderTarget2D rt{ renderTexture };
+
+		// マップ
+		for (int32 y = 0; y < MapSize.y; ++y)
+		{
+			for (int32 x = 0; x < MapSize.x; ++x)
+			{
+				// マップチップの描画座標
+				const Point pos{ (x * MapChip::MapChipSize), (y * MapChip::MapChipSize) };
+
+				// 地面のマップチップ
+				if (const int32 chipIndex = mapLayer0[y][x];
+					chipIndex != 0) // 0 の場合は描画しない
+				{
+					mapchip.get(chipIndex).draw(pos);
+				}
+
+				// 障害物のマップチップ
+				if (const int32 chipIndex = mapLayer1[y][x];
+					chipIndex == 2) // 0 の場合は描画しない
+				{
+					mapchip.get(chipIndex).draw(pos);
+				}
+			}
+		}
+
+		// 敵キャラクターの描画
+		for (auto& enemy : enemies) enemy->draw();
 
 		// オブジェクトの描画
 		{
 			for (const auto& stair : stairs)  stair->draw();
-        }
+		}
 
 		// ゲームクリア領域
 		gameClearBody.draw(Color{ 255, 255, 0 });
 
-        {
+		{
 			//歩行アニメーションのインデックス(0, 1, 2)
 			player.draw();
-        }
-    }
+		}
+	}
 }

--- a/Minge2022Summer/src/Scenes/Game.hpp
+++ b/Minge2022Summer/src/Scenes/Game.hpp
@@ -19,7 +19,6 @@ private:
 
 	RenderTexture renderTexture;
 
-    SwordZombie swordzombie[MAXSWORDZOMBIESNUM];
     int32 countswordzombies;
 	// マップのセルの数（横 20, 縦 15 マス）
 	Size MapSize{26, 50};
@@ -29,15 +28,7 @@ private:
     Array<Enemy*> enemies;
     Vec2 enemiespos[MAXENEMIESNUM];
 
-    
-    ////////////////////////
-    // プレイヤーの初期化
-    ////////////////////////
-
-
 	Player player;
-
-
     
 	// ゲームクリア領域
 	Circle gameClearBody{ Vec2{ 16 * 16 + 8, 16 * 4 + 8}, 8 };


### PR DESCRIPTION
Enemyクラス諸々を改修しました。

- 敵との当たり判定は敵の位置を格納した配列を渡すのではなく、`detectEnemyCollision(Enemy *)`という関数をEnemy範囲for文で呼ぶよう変更
- すべての敵を同一配列に格納するように変更

```c++
// layer1上の敵を読み込む
	for (int32 y = 0; y < MapSize.y; ++y)
	{
		for (int32 x = 0; x < MapSize.x; ++x)
		{
			const Point pos{ (x * MapChip::MapChipSize), (y * MapChip::MapChipSize) };
			switch(mapLayer1[y][x])
			{
			case 5:
				enemies << new SwordZombie(pos);
				break;
			}
		}
	}
```
GameのInitで、layer1.csvで5番で指定された位置に剣術ゾンビを配置するようになっています。SwordZombieクラスはEnemyを継承しているので、`enemis`というEnemyポインタ配列に格納できます。新しい敵を作るときはswich-caseに同様に追加してください。

敵キャラクターの追加はSwordZombie.hpp/cppを参考に、Enemyクラスを継承したうえでupdateやdraw関数をオーバーライド（親クラスの関数の中身を上書き）して実装してください。

Characterクラスのupdate, drawを仮想関数にしておきました。

PR確認は、実行時の動き自体は何も変わらずエラーが起きなければOKです。

close #64 