### PR TITLE
Feature/#10/bomb

### DIFF
--- a/Minge2022Summer/Minge2022Summer.vcxproj
+++ b/Minge2022Summer/Minge2022Summer.vcxproj
@@ -121,6 +121,7 @@
     <ClCompile Include="src\Scenes\Enemies\SwordZombie.cpp" />
     <ClCompile Include="src\Scenes\Game.cpp" />
     <ClCompile Include="src\Scenes\GameClear.cpp" />
+    <ClCompile Include="src\Scenes\Objects\Bomb.cpp" />
     <ClCompile Include="src\Scenes\Objects\Stair.cpp" />
     <ClCompile Include="src\Scenes\Title.cpp" />
     <ClCompile Include="stdafx.cpp">

--- a/Minge2022Summer/Minge2022Summer.vcxproj.filters
+++ b/Minge2022Summer/Minge2022Summer.vcxproj.filters
@@ -168,6 +168,12 @@
     <ClCompile Include="src\LoadCSV.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Scenes\Objects\Stair.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Scenes\Objects\Bomb.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Image Include="App\icon.ico">

--- a/Minge2022Summer/src/Player.cpp
+++ b/Minge2022Summer/src/Player.cpp
@@ -45,6 +45,12 @@ void Player::detectObjCollision(Object* obj) {
 			stair->reverseLock = false;
 		}
 	}
+
+	if (Bomb* bomb = dynamic_cast<Bomb*>(obj)) {
+		if (bomb->state && bomb->position.distanceFrom(pos) <= bomb->range) {
+			this->hp--;
+		}
+	}
 }
 
 void Player::draw() const {

--- a/Minge2022Summer/src/Scenes/Game.cpp
+++ b/Minge2022Summer/src/Scenes/Game.cpp
@@ -42,9 +42,23 @@ Game::Game(const InitData& init)
 
 void Game::update()
 {
+	// =========== デバッグ ==========
+	if (KeyB.down()) objects << new Bomb(player.pos); // 敵用の爆弾の設置
+	// ===============================
+
 	// オブジェクトの状態更新
 	{
-		for (const auto& obj : objects)  obj->update();
+		for (auto obj = objects.begin(); obj != objects.end(); obj++) {
+			(*obj)->update();
+
+			// 削除フラグ確認
+			if ((*obj)->destructorFlag) {
+				delete* obj;
+				obj = objects.erase(obj);
+
+				if (obj == objects.end()) break; // 削除した結果末尾だったらループを抜ける
+			}
+		}
 	}
 
 	// カメラの移動

--- a/Minge2022Summer/src/Scenes/Objects/Bomb.cpp
+++ b/Minge2022Summer/src/Scenes/Objects/Bomb.cpp
@@ -1,0 +1,31 @@
+﻿#include "Object.hpp"
+
+Bomb::Bomb(Vec2 pos, SecondsF limit, int32 range)
+	: position(pos), timer{ limit }, timeLimit(limit), range(range)
+{
+	timer.start();
+}
+
+void Bomb::update() {
+	// 爆発のカウントダウン確認
+	if (state == 0 && timer.sF() == 0) {
+		state = 1; // 爆発中状態に変更
+		timer.set(0.5s); // 爆風の残存時間は0.5秒
+		timer.start();
+	}
+
+	// 消滅判定
+	if (state == 1 && timer.sF() == 0) destructorFlag = true;
+}
+
+void Bomb::draw() const {
+	// 爆発待機
+	if (state == 0) {
+		Circle{ position, 8 }.draw(Palette::Darkgray);
+	}
+
+	//爆発中
+	if (state == 1) {
+		Circle{ position, range }.draw(Color{ Palette::Red, 100 });
+	}
+}

--- a/Minge2022Summer/src/Scenes/Objects/Object.hpp
+++ b/Minge2022Summer/src/Scenes/Objects/Object.hpp
@@ -9,6 +9,8 @@ public:
 	int animNum;
 	int animIndex;
 
+	bool destructorFlag = false; // 削除フラグ
+
 	virtual void update() {}
 	virtual void draw() const {}
 	virtual ~Object() {}
@@ -27,6 +29,25 @@ public:
 	const Vec2 size;
 
 	Stair(Vec2 _inPos, Vec2 _outPos, bool _isReversable);
+
+	void update() override;
+
+	void draw() const override;
+};
+
+
+
+class Bomb : public Object {
+private:
+	SecondsF timeLimit;
+	Timer timer;
+
+public:
+	Vec2 position;
+	int32 state = 0; // 現在の状態（0: 爆発待機 1: 爆発中）
+	int32 range; // 爆発範囲
+
+	Bomb(Vec2 pos, SecondsF limit = 3s, int32 range = 16);
 
 	void update() override;
 


### PR DESCRIPTION
Close #10 
# 変更内容
- 敵用の爆弾を実装
デバッグ用にBキーで設置できるようになっています。
- オブジェクトの削除処理を追加

# 詳細
- 敵用の爆弾
`Bomb(Vec2 pos, SecondsF limit = 3s, int32 range = 16)`
pos: 座標
limit: 爆発までの時間
range: 爆発範囲
- オブジェクトの削除処理
`Object`クラスに`bool destructorFlag`変数を追加しました。この値が`true`になるとGame.cppで削除処理がされます。